### PR TITLE
- Fix compilation on OSX using clang-3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,14 @@
-cmake_minimum_required (VERSION 2.8.9)
+cmake_minimum_required (VERSION 3.1 )
 project (HPMVS)
 
 ADD_DEFINITIONS(
-    -std=c++11
     -O3
 )
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 #find_package(Loccom REQUIRED)
-find_package(Eigen3 REQUIRED)
+find_package(Eigen REQUIRED)
 find_package(JPEG REQUIRED)
 find_package(Gflags REQUIRED)
 add_definitions(-DHPMVS_GFLAGS_NAMESPACE=${GFLAGS_NAMESPACE})
@@ -38,7 +37,7 @@ endif()
 
 include_directories(
 	"${PROJECT_SOURCE_DIR}/include"
-	${EIGEN3_INCLUDE_DIR}
+	${EIGEN_INCLUDE_DIR}
 	${JPEG_INCLUDE_DIR}
 	${GFLAGS_INCLUDE_DIRS}
 	${GLOG_INCLUDE_DIRS}
@@ -51,5 +50,6 @@ include_directories(
 
 add_executable (hpmvs src/main.cpp ${MY_SRC})
 target_link_libraries(hpmvs ${JPEG_LIBRARIES} ${GFLAGS_LIBRARIES} ${GLOG_LIBRARIES} nlopt stlplus3)
+set_property(TARGET hpmvs PROPERTY CXX_STANDARD 11)
 
 install(TARGETS hpmvs RUNTIME DESTINATION bin)

--- a/include/hpmvs/Patch3d.h
+++ b/include/hpmvs/Patch3d.h
@@ -24,6 +24,7 @@
 #include <Eigen/Dense>
 #include <atomic>
 #include <memory>
+#include <vector>
 
 namespace mo3d {
 

--- a/src/hpmvs/PatchOptimizer.cpp
+++ b/src/hpmvs/PatchOptimizer.cpp
@@ -18,6 +18,7 @@
 * along with HPMVS. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <numeric>
 #include <set>
 #include <iomanip>
 


### PR DESCRIPTION
Here is a simple fix used to enhance compilation on compliant platforms. 

There are three fixes : 
- the first one is to force using your cmake/FindEigen instead of the system one ;
- the second one is to use the -std=c++11 as a cmake macro (this enhance portability) 
- the third ones are just two missing includes. 

Note : I didn't fix one thing : the include <omp.h> in main.cpp. If the target doesn't have openmp (which is the default on clang shipped with Xcode), this cause a compilation error. You may indicate to the user that you require openmp or use #ifdef/#define to prevent missing include. 

Hope it helps. 
